### PR TITLE
Do not automatically join using filter().

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2856,7 +2856,7 @@ class Query(Node):
             for side, piece in (('lhs', curr.lhs), ('rhs', curr.rhs)):
                 if isinstance(piece, DQ):
                     query, joins = self.convert_dict_to_node(piece.query)
-                    dq_joins.update(joins)
+                    # dq_joins.update(joins)
                     expression = reduce(operator.and_, query)
                     # Apply values from the DQ object.
                     expression._negated = piece._negated

--- a/peewee.py
+++ b/peewee.py
@@ -2856,7 +2856,8 @@ class Query(Node):
             for side, piece in (('lhs', curr.lhs), ('rhs', curr.rhs)):
                 if isinstance(piece, DQ):
                     query, joins = self.convert_dict_to_node(piece.query)
-                    # dq_joins.update(joins)
+                    if any('__' in k for k in piece.query): # Is a DQ query, auto-join.
+                        dq_joins.update(joins)
                     expression = reduce(operator.and_, query)
                     # Apply values from the DQ object.
                     expression._negated = piece._negated


### PR DESCRIPTION
Initial testing shows this works. 

I can understand why it might be implemented this way originally if you have fake foreign keys that are invariants maintained in peewee and not by your database, but it doesn't make sense for us.