### PR TITLE
QoL Patch on MagicAll to always default to select all columns.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -239,6 +239,8 @@ Is the same as this:
 
 It's just a nomenclature I preferred from Django.  I made it uppercase to prevent conflicts with any columns named "all", and to highlight that it's effectively a constant.
 
+Notably, the ALL shortcut makes queries context independent. It selects all columns from the table whereas the default Peewee behaviour for `Person.select()` is context dependent. A normal query like `Person.select()` is equivalent to `select * from person`, but a subquery like `Article.select().join(Person.select())` becomes `select * from article join (select id from person)` by only selecting the primary key of subqueries using `select()` with no arguments. 
+
 
 A New (Additional) Join Syntax
 ------------------------------

--- a/peewee.py
+++ b/peewee.py
@@ -4896,10 +4896,10 @@ class MagicAll(object):
         self.__dict__['cls'] = cls
         
     def __iter__(self):
-      return self.__dict__['cls'].select().__iter__()
+      return self.__dict__['cls'].select(self.__dict__['cls']).__iter__()
       
     def __getattr__(self, name):
-        return getattr(self.__dict__['cls'].select(), name)
+        return getattr(self.__dict__['cls'].select(self.__dict__['cls']), name)
     
 
 class Model(with_metaclass(BaseModel)):


### PR DESCRIPTION
By default, `Model.select()` only selects all columns as a standalone query. If used like `Model.select().join(OtherModel.select(), on = predicate)`, `OtherModel` will only select the primary key.

This changes `MagicAll` to specify that we want `cls.select(cls)` which means `select cls.*`, even in subqueries.

Changing `.select` might be trivial but I haven't actually found where it changes the select arguments.